### PR TITLE
Correct “published specification” fields

### DIFF
--- a/javascript-mjs/draft.md
+++ b/javascript-mjs/draft.md
@@ -268,7 +268,7 @@ Interoperability considerations:
 
 Published specification:
 
-: \[this document]
+: {{ECMA-262}}
 
 Applications which use this media type:
 
@@ -345,7 +345,7 @@ Interoperability considerations:
 
 Published specification:
 
-: \[this document]
+: {{ECMA-262}}
 
 Applications which use this media type:
 
@@ -419,7 +419,7 @@ Interoperability considerations:
 
 Published specification:
 
-: \[this document]
+: {{ECMA-262}}
 
 Applications which use this media type:
 
@@ -493,7 +493,7 @@ Interoperability considerations:
 
 Published specification:
 
-: \[this document]
+: {{ECMA-262}}
 
 Applications which use this media type:
 
@@ -567,7 +567,7 @@ Interoperability considerations:
 
 Published specification:
 
-: \[this document]
+: {{ECMA-262}}
 
 Applications which use this media type:
 
@@ -641,7 +641,7 @@ Interoperability considerations:
 
 Published specification:
 
-: \[this document]
+: {{ECMA-262}}
 
 Applications which use this media type:
 
@@ -715,7 +715,7 @@ Interoperability considerations:
 
 Published specification:
 
-: \[this document]
+: {{ECMA-262}}
 
 Applications which use this media type:
 
@@ -789,7 +789,7 @@ Interoperability considerations:
 
 Published specification:
 
-: \[this document]
+: {{ECMA-262}}
 
 Applications which use this media type:
 
@@ -862,7 +862,7 @@ Interoperability considerations:
 
 Published specification:
 
-: \[this document]
+: {{ECMA-262}}
 
 Applications which use this media type:
 
@@ -937,7 +937,7 @@ Interoperability considerations:
 
 Published specification:
 
-: \[this document]
+: {{ECMA-262}}
 
 Applications which use this media type:
 
@@ -1010,7 +1010,7 @@ Interoperability considerations:
 
 Published specification:
 
-: \[this document]
+: {{ECMA-262}}
 
 Applications which use this media type:
 
@@ -1083,7 +1083,7 @@ Interoperability considerations:
 
 Published specification:
 
-: \[this document]
+: {{ECMA-262}}
 
 Applications which use this media type:
 
@@ -1156,7 +1156,7 @@ Interoperability considerations:
 
 Published specification:
 
-: \[this document]
+: {{ECMA-262}}
 
 Applications which use this media type:
 
@@ -1229,7 +1229,7 @@ Interoperability considerations:
 
 Published specification:
 
-: \[this document]
+: {{ECMA-262}}
 
 Applications which use this media type:
 
@@ -1302,7 +1302,7 @@ Interoperability considerations:
 
 Published specification:
 
-: \[this document]
+: {{ECMA-262}}
 
 Applications which use this media type:
 
@@ -1375,7 +1375,7 @@ Interoperability considerations:
 
 Published specification:
 
-: \[this document]
+: {{ECMA-262}}
 
 Applications which use this media type:
 


### PR DESCRIPTION
This is based on feedback by expert & RFC 6838 author Ned Freed. About the field:

"""
Generally speaking it should reference the format specification. However, this
can get tricky when the registration is itself in a standards document that
doesn't itself contain the format specification, but references it. What if the
standards document is updated and the pointer to the proper specification
changes?

In the case of IETF specifications IANA is part of update process and will
update the registration. But that may not be the case with other standards
bodies — they may not see the need to update the specification.

Also remember that a specification is only required for standards tree
types.

tl;dr Reference the actual format specification if possible, but be aware
there can be issues.
"""